### PR TITLE
Add taxCode field to Company and Customer models

### DIFF
--- a/alegra/models/company.py
+++ b/alegra/models/company.py
@@ -1,4 +1,5 @@
 import re
+from enum import Enum
 from typing import Dict, Optional
 
 from pydantic import BaseModel, EmailStr, field_validator, model_validator
@@ -51,6 +52,16 @@ class NotificationByEmail(BaseModel):
     enabled: bool = False
 
 
+class TaxCode(BaseModel):
+    class TaxType(str, Enum):
+        IVA = "01"
+        INC = "04"
+        IVA_AND_INC = "ZA"
+        NOT_APPLICABLE = "ZZ"
+
+    id: TaxType
+
+
 class Company(BaseModel):
     id: Optional[str] = None
     name: str
@@ -61,6 +72,7 @@ class Company(BaseModel):
     organizationType: int
     identificationType: str
     regimeCode: str = ""
+    taxCode: TaxCode
     email: EmailStr
     phone: Optional[str] = ""
     address: Address

--- a/alegra/models/customer.py
+++ b/alegra/models/customer.py
@@ -3,11 +3,12 @@ from typing import Optional
 from pydantic import BaseModel, EmailStr
 
 from alegra.models.address import Address
-from alegra.models.phone_number import PhoneNumber
+from alegra.models.company import TaxCode
 
 
 class Customer(BaseModel):
     name: str
+    taxCode: TaxCode
     organizationType: int
     identificationType: str
     identificationNumber: Optional[str]

--- a/tests/fixtures/vcr_cassettes/test_create_company.yaml
+++ b/tests/fixtures/vcr_cassettes/test_create_company.yaml
@@ -23,7 +23,7 @@ interactions:
   response:
     body:
       string: '{"company":{"id":"01JMZ1SM8JDHAPF4VSFC595WAK","name":"Soluciones Alegra
-        S.A.S","identification":"111111111","dv":"2","type":"associated","useAlegraCertificate":true,"governmentStatus":{},"notificationByEmail":{"enabled":false},"webhooks":{},"organizationType":1,"identificationType":"31","regimeCode":"R-99-PN","email":"email@email.com","phone":"1234567890","address":{"address":"Cra.
+        S.A.S","identification":"111111111","dv":"2","type":"associated","useAlegraCertificate":true,"governmentStatus":{},"notificationByEmail":{"enabled":false},"webhooks":{},"organizationType":1,"identificationType":"31","regimeCode":"R-99-PN","taxCode": {"id": "ZZ"},"email":"email@email.com","phone":"1234567890","address":{"address":"Cra.
         13 #12-12 Edificio A & A","city":"11001","department":"11","country":"CO"}}}'
     headers:
       Apigw-Requestid:

--- a/tests/fixtures/vcr_cassettes/test_create_invoice.yaml
+++ b/tests/fixtures/vcr_cassettes/test_create_invoice.yaml
@@ -4,7 +4,7 @@ interactions:
       "prefix": "SETP", "minNumber": 990000000, "maxNumber": 995000000, "startDate":
       "2019-01-19", "endDate": "2030-01-19", "technicalKey": "fc8eac422eba16e22ffd8c6f94b3f40a6e38162c"},
       "company": {"id": "01HTJ3D9NZA79Z6BRNHB19C6Z0"}, "customer": {"name": "Customer
-      Name", "organizationType": 2, "identificationType": "13", "identificationNumber":
+      Name", "taxCode": "01", "organizationType": 2, "identificationType": "13", "identificationNumber":
       "222222222222", "dv": "2", "email": "email@email.com", "address": {"address":
       "Cra. 13 #12-12 Edificio A & A", "city": "11001", "department": "11", "country":
       "CO"}, "phone": "3223334455"}, "number": 990015000, "note": "Nota relativa al

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -3,7 +3,7 @@ from vcr.unittest import VCRTestCase
 
 from alegra.client import ApiClient
 from alegra.config import ApiConfig
-from alegra.models.company import Address, Company, GovernmentStatus
+from alegra.models.company import Address, Company, GovernmentStatus, TaxCode
 
 
 class TestCompanyResource(VCRTestCase):
@@ -25,6 +25,7 @@ class TestCompanyResource(VCRTestCase):
             organizationType=1,
             identificationType="31",
             regimeCode="R-99-PN",
+            taxCode=TaxCode(id="ZZ"),
             email="email@email.com",
             phone="1234567890",
             address=Address(
@@ -41,6 +42,7 @@ class TestCompanyResource(VCRTestCase):
         self.assertEqual(company.identification, "111111111")
         self.assertEqual(company.dv, "2")
         self.assertTrue(company.useAlegraCertificate)
+        self.assertEqual(company.taxCode.id, "ZZ")
         self.assertEqual(company.organizationType, 1)
         self.assertEqual(company.identificationType, "31")
         self.assertEqual(company.regimeCode, "R-99-PN")

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -39,6 +39,7 @@ class TestInvoiceResource(VCRTestCase):
                         "country": "CO",
                     },
                     "name": "Customer Name",
+                    "taxCode": {"id": "01"},
                     "organizationType": 2,
                     "identificationType": "13",
                     "identificationNumber": "222222222222",


### PR DESCRIPTION
Add a new TaxCode model with TaxType enum for Colombian tax types (IVA, INC, etc.), and integrate taxCode field into Company and Customer models.